### PR TITLE
make maskrcnn training spot compatible - auto derive checkpoint if it…

### DIFF
--- a/models/vision/detection/scripts/train_ec2_single_node.sh
+++ b/models/vision/detection/scripts/train_ec2_single_node.sh
@@ -32,5 +32,5 @@ python tools/train.py \
 --validate \
 --autoscale-lr \
 --amp
-# --resume_from /deep-learning-models/models/vision/detection/work_dirs/retinanet_r50_fpn_1x_amp_bn/000
+--resume_dir /deep-learning-models/models/vision/detection/work_dirs/faster_rcnn_r50_fpn_1x_coco
 

--- a/models/vision/detection/tools/train.py
+++ b/models/vision/detection/tools/train.py
@@ -56,7 +56,8 @@ def parse_args():
     parser.add_argument('--config', help='train config file path')
     parser.add_argument("--model_dir", help="Location of model on Sagemaker instance")
     parser.add_argument('--work_dir', help='the dir to save logs and models')
-    parser.add_argument('--resume_dir', help='restarts training from saved running state in provided directory')
+    parser.add_argument('--resume_from', help='restarts training from saved running state in provided directory')
+    parser.add_argument('--resume_dir', help='restarts training from the latest running state in provided directory - useful for spot training')
     parser.add_argument('--amp', type=str2bool, nargs='?', const=True, default=True, help='enable mixed precision training')
     parser.add_argument('--validate', type=str2bool, nargs='?', const=True, default=True, help='whether to evaluate the checkpoint during training')
     parser.add_argument('--seed', type=int, default=17, help='random seed')
@@ -108,6 +109,8 @@ def main_ec2(args, cfg):
     # update configs according to CLI args
     if args.work_dir is not None:
         cfg.work_dir = args.work_dir
+    if args.resume_from is not None:
+        cfg.resume_from = args.resume_from
     if args.resume_dir is not None:
         if os.path.exists(args.resume_dir):
             logger.info("RESUMING TRAINING")

--- a/models/vision/detection/tools/train.py
+++ b/models/vision/detection/tools/train.py
@@ -113,9 +113,12 @@ def main_ec2(args, cfg):
             logger.info("RESUMING TRAINING")
             # get the latest checkpoint
             all_chkpt = [os.path.join(args.resume_dir,d) for d in os.listdir(args.resume_dir) if os.path.isdir(os.path.join(args.resume_dir,d))]
-            latest_chkpt = max(all_chkpt, key=os.path.getmtime)
-            # set the latest checkpoint to resume_from
-            cfg.resume_from = latest_chkpt
+            if not all_chkpt:
+               cfg.resume_from = None
+            else: 
+               latest_chkpt = max(all_chkpt, key=os.path.getmtime)
+               # set the latest checkpoint to resume_from
+               cfg.resume_from = latest_chkpt
         else:
             logger.info("CHECKPOINT NOT FOUND, RESTARTING TRAINING")
             cfg.resume_from = None

--- a/models/vision/detection/tools/train.py
+++ b/models/vision/detection/tools/train.py
@@ -56,7 +56,7 @@ def parse_args():
     parser.add_argument('--config', help='train config file path')
     parser.add_argument("--model_dir", help="Location of model on Sagemaker instance")
     parser.add_argument('--work_dir', help='the dir to save logs and models')
-    parser.add_argument('--resume_from', help='restarts training from saved running state in provided directory')
+    parser.add_argument('--resume_dir', help='restarts training from saved running state in provided directory')
     parser.add_argument('--amp', type=str2bool, nargs='?', const=True, default=True, help='enable mixed precision training')
     parser.add_argument('--validate', type=str2bool, nargs='?', const=True, default=True, help='whether to evaluate the checkpoint during training')
     parser.add_argument('--seed', type=int, default=17, help='random seed')
@@ -97,6 +97,10 @@ def print_model_info(model, logger):
 
 
 def main_ec2(args, cfg):
+    # start logger
+    timestamp = time.strftime('%Y%m%d_%H%M%S', time.localtime())
+    log_file = osp.join(cfg.work_dir, '{}.log'.format(timestamp))
+    logger = get_root_logger(log_file=log_file, log_level=cfg.log_level)
     """
     Main training entry point for jobs launched directly on EC2 instances
     """
@@ -104,8 +108,17 @@ def main_ec2(args, cfg):
     # update configs according to CLI args
     if args.work_dir is not None:
         cfg.work_dir = args.work_dir
-    if args.resume_from is not None:
-        cfg.resume_from = args.resume_from
+    if args.resume_dir is not None:
+        if os.path.exists(args.resume_dir):
+            logger.info("RESUMING TRAINING")
+            # get the latest checkpoint
+            all_chkpt = [os.path.join(args.resume_dir,d) for d in os.listdir(args.resume_dir) if os.path.isdir(os.path.join(args.resume_dir,d))]
+            latest_chkpt = max(all_chkpt, key=os.path.getmtime)
+            # set the latest checkpoint to resume_from
+            cfg.resume_from = latest_chkpt
+        else:
+            logger.info("CHECKPOINT NOT FOUND, RESTARTING TRAINING")
+            cfg.resume_from = None
 
     if args.autoscale_lr:
         # apply the linear scaling rule (https://arxiv.org/abs/1706.02677)
@@ -122,10 +135,6 @@ def main_ec2(args, cfg):
 
     # create work_dir
     mkdir_or_exist(osp.abspath(cfg.work_dir))
-    # init the logger before other steps
-    timestamp = time.strftime('%Y%m%d_%H%M%S', time.localtime())
-    log_file = osp.join(cfg.work_dir, '{}.log'.format(timestamp))
-    logger = get_root_logger(log_file=log_file, log_level=cfg.log_level)
     # log some basic info
     logger.info('Distributed training: {}'.format(distributed))
     logger.info('TF MMDetection Version: {}'.format(__version__))


### PR DESCRIPTION
…s exits

*Issue #, if available:*

*Description of changes:*
Making MaskRCNN spot compatible. Rather than providing a checkpoint, you provide a directory where all checkpoints exist. train script will find the latest one and resume. If it doesnt will restart training automatically. Can be used from rehydrating from S3 or FSx

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
